### PR TITLE
Fix documentation typo

### DIFF
--- a/include/qpdf/QPDFArgParser.hh
+++ b/include/qpdf/QPDFArgParser.hh
@@ -35,7 +35,7 @@
 // crafted to work with qpdf. qpdf's command-line syntax is very
 // complex because of its long history, and it doesn't really follow
 // any kind of normal standard for arguments, but it's important for
-// backward compatibility not ensure we don't break what constitutes a
+// backward compatibility to ensure we don't break what constitutes a
 // valid command. This class handles the quirks of qpdf's argument
 // parsing, bash/zsh completion, and support for @argfile to read
 // arguments from a file.

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -2753,7 +2753,7 @@ QPDFJob::handlePageSpecs(
             // survives through copying to the output but gets cleaned up
             // automatically at the end. Do not canonicalize the file
             // name. Using two different paths to refer to the same
-            // file is a document workaround for duplicating a page.
+            // file is a documented workaround for duplicating a page.
             // If you are using this an example of how to do this with
             // the API, you can just create two different QPDF objects
             // to the same underlying file with the same path to

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -1970,7 +1970,7 @@ QPDFJob::doProcess(
     // a password encoded in PDF Doc encoding or Windows code page
     // 1252 for an AES-encrypted file or a UTF-8-encoded password on
     // an RC4-encrypted file, or if the password was properly encoded
-    // by the password given here was incorrectly encoded, there's a
+    // but the password given here was incorrectly encoded, there's a
     // good chance we'd succeed here.
 
     std::string ptemp;


### PR DESCRIPTION
Is it actually still true that his is a documented work-around?

If so, what issue does the work around address given that on the face of it duplicating pages works?

If not, should the whole sentence be removed?